### PR TITLE
Do not include MethodOrProcHelper in ResourceController

### DIFF
--- a/lib/active_admin/base_controller/authorization.rb
+++ b/lib/active_admin/base_controller/authorization.rb
@@ -1,7 +1,6 @@
 module ActiveAdmin
   class BaseController < ::InheritedResources::Base
     module Authorization
-      include MethodOrProcHelper
       extend ActiveSupport::Concern
 
       ACTIONS_DICTIONARY = {
@@ -100,7 +99,7 @@ module ActiveAdmin
       end
 
       def dispatch_active_admin_access_denied(exception)
-        call_method_or_exec_proc active_admin_namespace.on_unauthorized_access, exception
+        instance_exec(self, exception, &active_admin_namespace.on_unauthorized_access.to_proc)
       end
 
       def rescue_active_admin_access_denied(exception)

--- a/lib/active_admin/batch_actions/controller.rb
+++ b/lib/active_admin/batch_actions/controller.rb
@@ -7,7 +7,7 @@ module ActiveAdmin
         if action_present?
           selection  =            params[:collection_selection] || []
           inputs     = JSON.parse params[:batch_action_inputs]  || '{}'
-          valid_keys = render_in_context(self, current_batch_action.inputs).try(:keys)
+          valid_keys = StringSymbolOrProcSetting.new(current_batch_action.inputs).value(self).try(:keys)
           inputs     = inputs.with_indifferent_access.slice *valid_keys
           instance_exec selection, inputs, &current_batch_action.block
         else

--- a/lib/active_admin/resource_controller/scoping.rb
+++ b/lib/active_admin/resource_controller/scoping.rb
@@ -15,7 +15,7 @@ module ActiveAdmin
       # Collection can be scoped conditionally with an :if or :unless proc.
       def begin_of_association_chain
         return nil unless active_admin_config.scope_to?(self)
-        render_in_context(self, active_admin_config.scope_to_method)
+        StringSymbolOrProcSetting.new(active_admin_config.scope_to_method).value(self)
       end
 
       # Overriding from InheritedResources::BaseHelpers

--- a/spec/unit/resource_controller_spec.rb
+++ b/spec/unit/resource_controller_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe "A specific resource controller", type: :controller do
 
   describe "performing batch_action" do
     let(:batch_action) { ActiveAdmin::BatchAction.new :flag, "Flag", &batch_action_block }
-    let(:batch_action_block) { proc { } }
+    let(:batch_action_block) { proc { self.instance_variable_set :@block_context, self.class } }
     let(:params) { ActionController::Parameters.new(http_params) }
 
     before do
@@ -239,8 +239,8 @@ RSpec.describe "A specific resource controller", type: :controller do
       end
 
       it "should call the block in controller scope" do
-        expect(controller).to receive(:render_in_context).with(controller, nil).and_return({})
         controller.batch_action
+        expect(controller.instance_variable_get(:@block_context)).to eq Admin::PostsController
       end
     end
 


### PR DESCRIPTION
Since MethodOrProcHelper was included in ResourceController render_in_context() has been used in two additional pull requests (scope_to) and (batch_action). This PR replaces render_in_context() with StringSymbolOrProcSetting and replaces call_method_or_exec_proc with a vanilla instance_exec().