### PR TITLE
Refactor router

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -135,14 +135,18 @@ module ActiveAdmin
       load_paths.flatten.compact.uniq.flat_map{ |path| Dir["#{path}/**/*.rb"] }
     end
 
-    def router
-      @router ||= Router.new(self)
-    end
-
-    # One-liner called by user's config/routes.rb file
+    # Creates all the necessary routes for the ActiveAdmin configurations
+    #
+    # Use this within the routes.rb file:
+    #
+    #   Application.routes.draw do |map|
+    #     ActiveAdmin.routes(self)
+    #   end
+    #
+    # @param rails_router [ActionDispatch::Routing::Mapper]
     def routes(rails_router)
       load!
-      router.apply(rails_router)
+      Router.new(router: rails_router, namespaces: namespaces).apply
     end
 
     # Adds before, around and after filters to all controllers.

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -33,7 +33,7 @@ module ActiveAdmin
     def define_resource_routes(router)
       resources = @application.namespaces.flat_map{ |n| n.resources.values }
       resources.each do |config|
-        routes = resource_routes(router, config)
+        routes = proc { resource_routes(router, config) }
 
         # Add in the parent if it exists
         if config.belongs_to?
@@ -65,7 +65,6 @@ module ActiveAdmin
     end
 
     def resource_routes(router, config)
-      Proc.new do
         case config
         when ::ActiveAdmin::Resource
           router.resources config.resource_name.route_key, only: config.defined_actions do
@@ -90,7 +89,6 @@ module ActiveAdmin
           raise "Unsupported config class: #{config.class}"
         end
       end
-    end
 
     # Deals with +ControllerAction+ instances
     # Builds one route for each HTTP verb passed in

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -12,6 +12,7 @@ module ActiveAdmin
     #     ActiveAdmin.routes(self)
     #   end
     #
+    # @param router [ActionDispatch::Routing::Mapper]
     def apply(router)
       define_root_routes(router)
       define_resources_routes(router)
@@ -40,12 +41,7 @@ module ActiveAdmin
     end
 
     def define_resource_routes(router, config)
-      routes = proc { resource_routes(router, config) }
-
-      # Add in the parent if it exists
-      if config.belongs_to?
-        routes     = proc { define_belongs_to_routes(router, config) }
-      end
+      routes = proc { define_routes(router, config) }
 
         # Add on the namespace if required
       unless config.namespace.root?
@@ -54,6 +50,14 @@ module ActiveAdmin
       end
 
       routes.call
+    end
+
+    def define_routes(router, config)
+      if config.belongs_to?
+        define_belongs_to_routes(router, config)
+      else
+        resource_routes(router, config)
+      end
     end
 
     def resource_routes(router, config)

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -1,19 +1,13 @@
 module ActiveAdmin
+  # @private
   class Router
-    def initialize(application)
-      @application = application
+    attr_reader :namespaces, :router
+
+    def initialize(router:, namespaces:)
+      @router, @namespaces = router, namespaces
     end
 
-    # Creates all the necessary routes for the ActiveAdmin configurations
-    #
-    # Use this within the routes.rb file:
-    #
-    #   Application.routes.draw do |map|
-    #     ActiveAdmin.routes(self)
-    #   end
-    #
-    # @param router [ActionDispatch::Routing::Mapper]
-    def apply(router)
+    def apply(router = @router)
       define_root_routes(router)
       define_resources_routes(router)
     end
@@ -21,7 +15,7 @@ module ActiveAdmin
     private
 
     def define_root_routes(router)
-      @application.namespaces.each do |namespace|
+      namespaces.each do |namespace|
         if namespace.root?
           router.root namespace.root_to_options.merge(to: namespace.root_to)
         else
@@ -34,7 +28,7 @@ module ActiveAdmin
 
     # Defines the routes for each resource
     def define_resources_routes(router)
-      resources = @application.namespaces.flat_map{ |n| n.resources.values }
+      resources = namespaces.flat_map{ |n| n.resources.values }
       resources.each do |config|
         define_resource_routes(router, config)
       end

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -51,11 +51,7 @@ module ActiveAdmin
         # Add on the namespace if required
       unless config.namespace.root?
         nested = routes
-        routes = Proc.new do
-          router.namespace config.namespace.name, config.namespace.route_options.dup do
-            nested.call
-          end
-        end
+        routes = proc { define_namespace(router, config, &nested) }
       end
 
       routes.call
@@ -113,5 +109,10 @@ module ActiveAdmin
       end
     end
 
+    def define_namespace(router, config)
+      router.namespace config.namespace.name, config.namespace.route_options.dup do
+        yield
+      end
+    end
   end
 end

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -44,8 +44,7 @@ module ActiveAdmin
 
       # Add in the parent if it exists
       if config.belongs_to?
-        belongs_to = routes
-        routes     = proc { define_belongs_to_routes(router, config, &belongs_to) }
+        routes     = proc { define_belongs_to_routes(router, config) }
       end
 
         # Add on the namespace if required
@@ -100,12 +99,12 @@ module ActiveAdmin
 
     def define_belongs_to_routes(router, config)
       # If it's optional, make the normal resource routes
-      yield if config.belongs_to_config.optional?
+      resource_routes(router, config) if config.belongs_to_config.optional?
 
       # Make the nested belongs_to routes
       # :only is set to nothing so that we don't clobber any existing routes on the resource
       router.resources config.belongs_to_config.target.resource_name.plural, only: [] do
-        yield
+        resource_routes(router, config)
       end
     end
 

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -41,14 +41,12 @@ module ActiveAdmin
     end
 
     def define_resource_routes(router, config)
-      routes = proc { define_routes(router, config) }
-
+      if config.namespace.root?
+        define_routes(router, config)
+      else
         # Add on the namespace if required
-      unless config.namespace.root?
-        routes = proc { define_namespace(router, config) }
+        define_namespace(router, config)
       end
-
-      routes.call
     end
 
     def define_routes(router, config)

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -45,8 +45,7 @@ module ActiveAdmin
 
         # Add on the namespace if required
       unless config.namespace.root?
-        nested = routes
-        routes = proc { define_namespace(router, config, &nested) }
+        routes = proc { define_namespace(router, config) }
       end
 
       routes.call
@@ -114,7 +113,7 @@ module ActiveAdmin
 
     def define_namespace(router, config)
       router.namespace config.namespace.name, config.namespace.route_options.dup do
-        yield
+        define_routes(router, config)
       end
     end
   end

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -68,14 +68,7 @@ module ActiveAdmin
       case config
       when ::ActiveAdmin::Resource
         router.resources config.resource_name.route_key, only: config.defined_actions do
-          router.member do
-            config.member_actions.each { |action| build_action(router, action) }
-          end
-
-          router.collection do
-            config.collection_actions.each { |action| build_action(router, action) }
-            router.post :batch_action if config.batch_actions_enabled?
-          end
+          define_actions(router, config)
         end
       when ::ActiveAdmin::Page
         page = config.underscored_resource_name
@@ -87,6 +80,18 @@ module ActiveAdmin
         end
       else
         raise "Unsupported config class: #{config.class}"
+      end
+    end
+
+    # Defines member and collection actions
+    def define_actions(router, config)
+      router.member do
+        config.member_actions.each { |action| build_action(router, action) }
+      end
+
+      router.collection do
+        config.collection_actions.each { |action| build_action(router, action) }
+        router.post :batch_action if config.batch_actions_enabled?
       end
     end
 

--- a/lib/active_admin/router.rb
+++ b/lib/active_admin/router.rb
@@ -45,16 +45,7 @@ module ActiveAdmin
       # Add in the parent if it exists
       if config.belongs_to?
         belongs_to = routes
-        routes     = Proc.new do
-          # If it's optional, make the normal resource routes
-          belongs_to.call if config.belongs_to_config.optional?
-
-          # Make the nested belongs_to routes
-          # :only is set to nothing so that we don't clobber any existing routes on the resource
-          router.resources config.belongs_to_config.target.resource_name.plural, only: [] do
-            belongs_to.call
-          end
-        end
+        routes     = proc { define_belongs_to_routes(router, config, &belongs_to) }
       end
 
         # Add on the namespace if required
@@ -110,5 +101,17 @@ module ActiveAdmin
     def build_route(router, verbs, *args)
       Array.wrap(verbs).each { |verb| router.send(verb, *args) }
     end
+
+    def define_belongs_to_routes(router, config)
+      # If it's optional, make the normal resource routes
+      yield if config.belongs_to_config.optional?
+
+      # Make the nested belongs_to routes
+      # :only is set to nothing so that we don't clobber any existing routes on the resource
+      router.resources config.belongs_to_config.target.resource_name.plural, only: [] do
+        yield
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This series of refactorings replaces all use of proc (x5) and instance_exec (x6) in Router with vanilla method calls, making it easier to understand and maintain.