### PR TITLE
Use template partial to render content of head

### DIFF
--- a/app/views/active_admin/_head.html.erb
+++ b/app/views/active_admin/_head.html.erb
@@ -1,0 +1,16 @@
+<title>
+  <%= [title, helpers.active_admin_namespace.site_title(self)].compact.join(" | ") %>
+</title>
+<% active_admin_application.stylesheets.each do |style, options| %>
+  <%= stylesheet_link_tag(style, options).html_safe %>
+<% end %>
+<% active_admin_namespace.meta_tags.each do |name, content| %>
+  <meta name="<%= name %>" content="<%= content %>">
+<% end %>
+<% active_admin_application.javascripts.each do |path| %>
+  <%= javascript_include_tag(path) %>
+<% end %>
+<% if active_admin_namespace.favicon %>
+  <%= favicon_link_tag(active_admin_namespace.favicon) %>
+<% end %>
+<%= csrf_meta_tag %>

--- a/lib/active_admin/views/pages/base.rb
+++ b/lib/active_admin/views/pages/base.rb
@@ -23,25 +23,7 @@ module ActiveAdmin
 
         def build_active_admin_head
           within head do
-            html_title [title, helpers.active_admin_namespace.site_title(self)].compact.join(" | ")
-
-            active_admin_application.stylesheets.each do |style, options|
-              text_node stylesheet_link_tag(style, options).html_safe
-            end
-
-            active_admin_namespace.meta_tags.each do |name, content|
-              text_node(tag(:meta, name: name, content: content))
-            end
-
-            active_admin_application.javascripts.each do |path|
-              text_node(javascript_include_tag(path))
-            end
-
-            if active_admin_namespace.favicon
-              text_node(favicon_link_tag(active_admin_namespace.favicon))
-            end
-
-            text_node csrf_meta_tag
+            render partial: 'active_admin/head', locals: { title: self.title, helpers: helpers }
           end
         end
 

--- a/spec/support/active_admin_integration_spec_helper.rb
+++ b/spec/support/active_admin_integration_spec_helper.rb
@@ -40,7 +40,9 @@ module ActiveAdminIntegrationSpecHelper
   end
 
   def render_arbre_component(assigns = {}, helpers = mock_action_view, &block)
-    arbre(assigns, helpers, &block).children.first
+    clear_lookup_context_template_cache do
+      arbre(assigns, helpers, &block).children.first
+    end
   end
 
   # A mock action view to test view helpers
@@ -81,5 +83,11 @@ module ActiveAdminIntegrationSpecHelper
     yield
   ensure
     I18n.backend.reload!
+  end
+
+  # FIXME: Find more elegant way to disable template caching in MockActionView.
+  def clear_lookup_context_template_cache
+    ActionView::LookupContext::DetailsKey.clear
+    yield.tap { ActionView::LookupContext::DetailsKey.clear }
   end
 end

--- a/spec/unit/authorization/controller_authorization_spec.rb
+++ b/spec/unit/authorization/controller_authorization_spec.rb
@@ -5,9 +5,14 @@ RSpec.describe "Controller Authorization", type: :controller do
   let(:authorization){ controller.send(:active_admin_authorization) }
 
   before do
+    ActionView::LookupContext::DetailsKey.clear
     load_resources { ActiveAdmin.register Post }
     @controller = Admin::PostsController.new
     allow(authorization).to receive(:authorized?)
+  end
+
+  after do
+    ActionView::LookupContext::DetailsKey.clear
   end
 
   it "should authorize the index action" do

--- a/spec/unit/views/pages/layout_spec.rb
+++ b/spec/unit/views/pages/layout_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe ActiveAdmin::Views::Pages::Layout do
       insert_tag ActiveAdmin::Views::Pages::Layout
     end
   end
+  let(:html) { layout.render_in layout.arbre_context }
+  let(:page) { Capybara.string(html) }
 
   it "should be the @page_title if assigned in the controller" do
     assigns[:page_title] = "My Page Title"
@@ -42,6 +44,14 @@ RSpec.describe ActiveAdmin::Views::Pages::Layout do
     helpers.params[:action] = "edit"
 
     expect(layout.title).to eq "Edit"
+  end
+
+  describe "the head" do
+
+    it "should have title tag" do
+      expect(page).to have_css 'head title', text: /Edit \|/, count: 1, visible: false
+    end
+
   end
 
   describe "the body" do


### PR DESCRIPTION
Allow an application to customize head by overriding the 'activeadmin/head' partial instead of overriding Pages::Base.build_active_admin_head.