### PR TITLE
Don't clobber defined controller action method if action DSL block not given

### DIFF
--- a/lib/active_admin/page_dsl.rb
+++ b/lib/active_admin/page_dsl.rb
@@ -20,8 +20,15 @@ module ActiveAdmin
 
     def page_action(name, options = {}, &block)
       config.page_actions << ControllerAction.new(name, options)
-      controller do
-        define_method(name, &block || Proc.new{})
+
+      if block_given?
+        controller do
+          define_method(name, &block)
+        end
+      elsif !controller.method_defined?(name)
+        controller do
+          define_method(name, Proc.new{})
+        end
       end
     end
 

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -131,14 +131,25 @@ module ActiveAdmin
     # action.
     #
     def action(set, name, options = {}, &block)
-      warn "Warning: method `#{name}` already defined" if controller.method_defined?(name)
-
       set << ControllerAction.new(name, options)
       title = options.delete(:title)
 
-      controller do
-        before_action(only: [name]) { @page_title = title } if title
-        define_method(name, &block || Proc.new{})
+      if title
+        controller do
+          before_action(only: [name]) { @page_title = title }
+        end
+      end
+  
+      if block_given?
+        warn "Warning: method `#{name}` already defined in #{controller.name}" if controller.method_defined?(name)
+
+        controller do
+          define_method(name, &block)
+        end
+      elsif !controller.method_defined?(name)
+        controller do
+          define_method(name, Proc.new{})
+        end
       end
     end
 

--- a/spec/unit/action_builder_spec.rb
+++ b/spec/unit/action_builder_spec.rb
@@ -132,7 +132,9 @@ RSpec.describe 'defining actions from registration blocks', type: :controller do
     describe 'defining member action' do
       let :action! do
         ActiveAdmin.register Post do
-          member_action :process
+          member_action :process do
+            # Do nothing
+          end
         end
       end
 
@@ -144,7 +146,9 @@ RSpec.describe 'defining actions from registration blocks', type: :controller do
     describe 'defining collection action' do
       let :action! do
         ActiveAdmin.register Post do
-          collection_action :process
+          collection_action :process do
+            # Do nothing
+          end
         end
       end
 


### PR DESCRIPTION
Preserves the option to define action methods directly in the controller class instead of requiring the method be injected using controller do ... end.