### PR TITLE
Simplify permitted params

### DIFF
--- a/lib/active_admin/resource.rb
+++ b/lib/active_admin/resource.rb
@@ -65,6 +65,9 @@ module ActiveAdmin
     # nil to not decorate.
     attr_accessor :decorator_class_name
 
+    # An array or proc returning whitelisted resource attribute names.
+    attr_accessor :permitted_attr_names
+
     module Base
       def initialize(namespace, resource_class, options = {})
         @namespace = namespace

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -301,6 +301,21 @@ module ActiveAdmin
         apply_decorator(resource)
       end
 
+      def permitted_params
+        permitted_params =
+          active_admin_namespace.permitted_params +
+            Array.wrap(active_admin_config.belongs_to_param)
+
+        permitted_params << :create_another if active_admin_config.create_another
+
+        param_key = active_admin_config.param_key
+
+        attr_names = active_admin_config.permitted_attr_names
+        permitted_attr_names = attr_names.is_a?(Proc) ? instance_exec(&attr_names) : attr_names
+
+        params.permit(*permitted_params, param_key.to_sym => permitted_attr_names)
+      end
+
       # @return [String]
       def smart_resource_url
         if create_another?

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -310,10 +310,14 @@ module ActiveAdmin
 
         param_key = active_admin_config.param_key
 
-        attr_names = active_admin_config.permitted_attr_names
-        permitted_attr_names = attr_names.is_a?(Proc) ? instance_exec(&attr_names) : attr_names
-
         params.permit(*permitted_params, param_key.to_sym => permitted_attr_names)
+      end
+
+      # @return [Array] names
+      #
+      def permitted_attr_names
+        attr_names = active_admin_config.permitted_attr_names
+        attr_names.is_a?(Proc) ? instance_exec(&attr_names) : attr_names
       end
 
       # @return [String]

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -61,20 +61,7 @@ module ActiveAdmin
     #   end
     #
     def permit_params(*args, &block)
-      param_key = config.param_key.to_sym
-      belongs_to_param = config.belongs_to_param
-      create_another_param = :create_another if config.create_another
-
-      controller do
-        define_method :permitted_params do
-          permitted_params =
-            active_admin_namespace.permitted_params +
-              Array.wrap(belongs_to_param) +
-              Array.wrap(create_another_param)
-
-          params.permit(*permitted_params, param_key => block ? instance_exec(&block) : args)
-        end
-      end
+      config.permitted_attr_names = block_given? ? block : args
     end
 
     # Configure the index page for the resource


### PR DESCRIPTION
Instead of dynamically injecting a new permitted_params method into each ResourceController subclass instead store and pass the configuration information to a common method in ResourceController.