### PR TITLE
Accept content_for(:page_title)

### DIFF
--- a/app/views/active_admin/_head.html.erb
+++ b/app/views/active_admin/_head.html.erb
@@ -1,4 +1,4 @@
-<title><%= [title, helpers.active_admin_namespace.site_title(self)].compact.join(" | ") %></title>
+<title><%= [page_title, site_title].compact.join(" | ") %></title>
 <% active_admin_application.stylesheets.each do |style, options| %>
   <%= stylesheet_link_tag(style, options).html_safe %>
 <% end %>

--- a/app/views/layouts/active_admin.html.arb
+++ b/app/views/layouts/active_admin.html.arb
@@ -1,6 +1,10 @@
 insert_tag Arbre::HTML::Document do
   head do
-    render partial: 'active_admin/head', locals: { title: page_title, helpers: helpers }
+    render partial: 'active_admin/head',
+           locals: {
+              page_title: page_title,
+              site_title: helpers.active_admin_namespace.site_title(self)
+            }
   end
   body(class: body_classes) do
     div id: "wrapper" do

--- a/app/views/layouts/active_admin.html.arb
+++ b/app/views/layouts/active_admin.html.arb
@@ -2,7 +2,7 @@ insert_tag Arbre::HTML::Document do
   head do
     render partial: 'active_admin/head',
            locals: {
-              page_title: page_title,
+              page_title: content_for(:page_title) || page_title,
               site_title: helpers.active_admin_namespace.site_title(self)
             }
   end
@@ -12,7 +12,7 @@ insert_tag Arbre::HTML::Document do
         unsupported_browser
       end
       header active_admin_namespace, current_menu
-      title_bar page_title, action_items_for_action
+      title_bar content_for(:page_title) || page_title, action_items_for_action
       div class: 'flashes' do
         flash_messages.each do |type, message|
           div message, class: "flash flash_#{type}"

--- a/lib/active_admin/base_controller.rb
+++ b/lib/active_admin/base_controller.rb
@@ -74,5 +74,18 @@ module ActiveAdmin
     def default_page_presenter
       PagePresenter.new
     end
+
+    def page_title
+      if page_presenter[:title]
+        helpers.render_or_call_method_or_proc_on(self, page_presenter[:title])
+      else
+        default_page_title
+      end
+    end
+    helper_method :page_title
+
+    def default_page_title
+      active_admin_config.name
+    end
   end
 end

--- a/lib/active_admin/resource_controller.rb
+++ b/lib/active_admin/resource_controller.rb
@@ -58,6 +58,43 @@ module ActiveAdmin
       end || super
     end
 
+    def page_title
+      if page_presenter[:title]
+        case params[:action].to_sym
+        when :index
+          case page_presenter[:title]
+          when Symbol, Proc
+            instance_exec(&page_presenter[:title])
+          else
+            page_presenter[:title]
+          end
+        else
+          helpers.render_or_call_method_or_proc_on(resource, page_presenter[:title])
+        end
+      else
+        default_page_title
+      end
+    end
+
+    def default_page_title
+      case params[:action].to_sym
+      when :index
+        active_admin_config.plural_resource_label
+      when :show
+        helpers.display_name(resource).present? ?
+          helpers.display_name(resource) :
+          "#{active_admin_config.resource_label} ##{resource.id}"
+      when :new, :edit
+        normalized_action = params[:action]
+        normalized_action = 'new' if normalized_action == 'create'
+        normalized_action = 'edit' if normalized_action == 'update'
+
+        ActiveAdmin::Localizers.resource(active_admin_config).t("#{normalized_action}_model")
+      else
+        I18n.t("active_admin.#{params[:action]}", default: params[:action].to_s.titleize)
+      end
+    end
+
     # Returns the renderer class to use for the given action.
     def renderer_for(action)
       Deprecation.warn "This method does not do anything and will be removed."

--- a/lib/active_admin/view_helpers/layout_helper.rb
+++ b/lib/active_admin/view_helpers/layout_helper.rb
@@ -20,47 +20,53 @@ module ActiveAdmin
       end
 
       def page_title
-        case params[:action].to_sym
-        when :index
-          if PageController === controller
-            if page_presenter[:title]
-              render_or_call_method_or_proc_on self, page_presenter[:title]
-            else
-              active_admin_config.name
-            end
-          else
-            if Proc === page_presenter[:title]
-              controller.instance_exec &page_presenter[:title]
-            else
-              page_presenter[:title] || assigns[:page_title] || active_admin_config.plural_resource_label
-            end
-          end
-        when :show
+        case controller
+        when ResourceController
           if page_presenter[:title]
-            render_or_call_method_or_proc_on(resource, page_presenter[:title])
-          else
-            assigns[:page_title] || begin
-              title = display_name(resource)
-              title = "#{active_admin_config.resource_label} ##{resource.id}" if title.blank?
-              title
-            end
-          end
-        when :new, :edit
-          if page_presenter[:title]
-            render_or_call_method_or_proc_on(resource, page_presenter[:title])
-          else
-            normalized_action = case params[:action]
-            when "create"
-              "new"
-            when "update"
-              "edit"
+            case params[:action].to_sym
+            when :index
+              case page_presenter[:title]
+              when Symbol, Proc
+                controller.instance_exec(&page_presenter[:title])
+              else
+                page_presenter[:title]
+              end
             else
-              params[:action]
+              render_or_call_method_or_proc_on(resource, page_presenter[:title])
             end
-            assigns[:page_title] || ActiveAdmin::Localizers.resource(active_admin_config).t("#{normalized_action}_model")
+          else
+            default_page_title
           end
         else
-          assigns[:page_title] || I18n.t("active_admin.#{params[:action]}", default: params[:action].to_s.titleize)
+          if page_presenter[:title]
+            render_or_call_method_or_proc_on(self, page_presenter[:title])
+          else
+            default_page_title
+          end
+        end
+      end
+
+      def default_page_title
+        case controller
+        when ResourceController
+          case params[:action].to_sym
+          when :index
+            active_admin_config.plural_resource_label
+          when :show
+            display_name(resource).present? ?
+              display_name(resource) :
+              "#{active_admin_config.resource_label} ##{resource.id}"
+          when :new, :edit
+            normalized_action = params[:action]
+            normalized_action = 'new' if normalized_action == 'create'
+            normalized_action = 'edit' if normalized_action == 'update'
+
+            ActiveAdmin::Localizers.resource(active_admin_config).t("#{normalized_action}_model")
+          else
+            I18n.t("active_admin.#{params[:action]}", default: params[:action].to_s.titleize)
+          end
+        else
+          active_admin_config.name
         end
       end
 

--- a/lib/active_admin/view_helpers/layout_helper.rb
+++ b/lib/active_admin/view_helpers/layout_helper.rb
@@ -19,57 +19,6 @@ module ActiveAdmin
         ]
       end
 
-      def page_title
-        case controller
-        when ResourceController
-          if page_presenter[:title]
-            case params[:action].to_sym
-            when :index
-              case page_presenter[:title]
-              when Symbol, Proc
-                controller.instance_exec(&page_presenter[:title])
-              else
-                page_presenter[:title]
-              end
-            else
-              render_or_call_method_or_proc_on(resource, page_presenter[:title])
-            end
-          else
-            default_page_title
-          end
-        else
-          if page_presenter[:title]
-            render_or_call_method_or_proc_on(self, page_presenter[:title])
-          else
-            default_page_title
-          end
-        end
-      end
-
-      def default_page_title
-        case controller
-        when ResourceController
-          case params[:action].to_sym
-          when :index
-            active_admin_config.plural_resource_label
-          when :show
-            display_name(resource).present? ?
-              display_name(resource) :
-              "#{active_admin_config.resource_label} ##{resource.id}"
-          when :new, :edit
-            normalized_action = params[:action]
-            normalized_action = 'new' if normalized_action == 'create'
-            normalized_action = 'edit' if normalized_action == 'update'
-
-            ActiveAdmin::Localizers.resource(active_admin_config).t("#{normalized_action}_model")
-          else
-            I18n.t("active_admin.#{params[:action]}", default: params[:action].to_s.titleize)
-          end
-        else
-          active_admin_config.name
-        end
-      end
-
       # Returns the sidebar sections to render for the current action
       def sidebar_sections_for_action
         if active_admin_config && active_admin_config.sidebar_sections?


### PR DESCRIPTION
Support customizing the page title using a Rails template feature instead of setting a :title option on a registered page presenter. 