### PR TITLE
Pass local variable `default_table_options` to partial `index_as_table`

### DIFF
--- a/app/views/active_admin/resource/_index_as_table.html.arb
+++ b/app/views/active_admin/resource/_index_as_table.html.arb
@@ -1,12 +1,4 @@
-table_options = {
-  id: "index_table_#{active_admin_config.resource_name.plural}",
-  class: "index_table index",
-  i18n: active_admin_config.resource_class,
-  sortable: true,
-  paginator: page_presenter[:paginator] != false,
-  row_class: page_presenter[:row_class]
-}
-index_table_for(collection, table_options) do |t|
+index_table_for(collection, default_table_options) do |t|
   selectable_column
   id_column if resource_class.primary_key
   active_admin_config.resource_columns.each do |attribute|

--- a/lib/active_admin/views/index_as_table.rb
+++ b/lib/active_admin/views/index_as_table.rb
@@ -226,20 +226,20 @@ module ActiveAdmin
     class IndexAsTable < ActiveAdmin::Component
 
       def build(page_presenter, collection)
+        table_options = {
+          id: "index_table_#{active_admin_config.resource_name.plural}",
+          class: "index_table index",
+          i18n: active_admin_config.resource_class,
+          sortable: true,
+          paginator: page_presenter[:paginator] != false,
+          row_class: page_presenter[:row_class]
+        }
         if page_presenter.block
-          table_options = {
-            id: "index_table_#{active_admin_config.resource_name.plural}",
-            class: "index_table index",
-            i18n: active_admin_config.resource_class,
-            sortable: true,
-            paginator: page_presenter[:paginator] != false,
-            row_class: page_presenter[:row_class]
-          }
           insert_tag IndexTableFor, collection, table_options do |t|
             instance_exec(t, &page_presenter.block)
           end
         else
-          render partial: 'index_as_table'
+          render partial: 'index_as_table', locals: { default_table_options: table_options }
         end
       end
 


### PR DESCRIPTION
This reduces the amount of boilerplate that you need to copy if you override the default _index_as_table partial.

There might be a more elegant approach but this will do for now.