### PR TITLE
Namespace#set_page_options

### DIFF
--- a/lib/active_admin/page_dsl.rb
+++ b/lib/active_admin/page_dsl.rb
@@ -15,7 +15,11 @@ module ActiveAdmin
     #   end
     #
     def content(options = {}, &block)
-      config.set_page_presenter :index, ActiveAdmin::PagePresenter.new(options, &block)
+      if block_given?
+        config.set_page_presenter :index, ActiveAdmin::PagePresenter.new(options, &block)
+      else
+        config.set_page_options :index, options
+      end
     end
 
     def page_action(name, options = {}, &block)

--- a/lib/active_admin/resource/page_presenters.rb
+++ b/lib/active_admin/resource/page_presenters.rb
@@ -12,6 +12,14 @@ module ActiveAdmin
         @page_presenters ||= {}
       end
 
+      # Sets page options for a given action
+      #
+      # @param [String, Symbol] action The action to store this configuration for
+      def set_page_options(action, options)
+        options[:as] ||= :table if action.to_sym == :index
+        set_page_presenter(action, PagePresenter.new(options))
+      end
+
       # Sets a page config for a given action
       #
       # @param [String, Symbol] action The action to store this configuration for

--- a/lib/active_admin/resource_dsl.rb
+++ b/lib/active_admin/resource_dsl.rb
@@ -66,17 +66,29 @@ module ActiveAdmin
 
     # Configure the index page for the resource
     def index(options = {}, &block)
-      options[:as] ||= :table
-      config.set_page_presenter :index, ActiveAdmin::PagePresenter.new(options, &block)
+      if block_given?
+        options[:as] ||= :table
+        config.set_page_presenter :index, ActiveAdmin::PagePresenter.new(options, &block)
+      else
+        config.set_page_options :index, options
+      end
     end
 
     # Configure the show page for the resource
     def show(options = {}, &block)
-      config.set_page_presenter :show, ActiveAdmin::PagePresenter.new(options, &block)
+      if block_given?
+        config.set_page_presenter :show, ActiveAdmin::PagePresenter.new(options, &block)
+      else
+        config.set_page_options :show, options
+      end
     end
 
     def form(options = {}, &block)
-      config.set_page_presenter :form, ActiveAdmin::PagePresenter.new(options, &block)
+      if block_given?
+        config.set_page_presenter :form, ActiveAdmin::PagePresenter.new(options, &block)
+      else
+        config.set_page_options :form, options
+      end
     end
 
     # Configure the CSV format


### PR DESCRIPTION
Implement new method `Namespace#set_page_options` that can be used to build a PagePresenter when a block is not present.