### PR TITLE
Extract partial `breadcrumbs`

### DIFF
--- a/app/views/active_admin/base/_breadcrumbs.html.arb
+++ b/app/views/active_admin/base/_breadcrumbs.html.arb
@@ -1,0 +1,8 @@
+if (links = breadcrumb_links) && links.size > 0
+  span class: "breadcrumb" do
+    links.each do |link|
+      text_node link
+      span("/", class: "breadcrumb_sep")
+    end
+  end
+end

--- a/app/views/active_admin/base/_title_bar.html.arb
+++ b/app/views/active_admin/base/_title_bar.html.arb
@@ -1,13 +1,6 @@
 div id: :title_bar, class: :title_bar do
   div id: "titlebar_left" do
-    if (links = breadcrumb_links) && links.size > 0
-      span class: "breadcrumb" do
-        links.each do |link|
-          text_node link
-          span("/", class: "breadcrumb_sep")
-        end
-      end
-    end
+    render partial: 'breadcrumbs'
     h2(page_title, id: 'page_title')
   end
   div id: "titlebar_right" do

--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -4,11 +4,18 @@ module ActiveAdmin
 
       # Returns an array of links to use in a breadcrumb
       def breadcrumb_links(path = request.path)
-        breadcrumb_config = active_admin_config && active_admin_config.breadcrumb
+        setting = active_admin_config.breadcrumb
 
-        return if breadcrumb_config.blank?
-        return instance_exec(controller, &breadcrumb_config) if breadcrumb_config.is_a?(Proc)
+        if setting.blank?
+          nil
+        elsif setting.is_a?(Proc)
+          instance_exec(controller, &setting)
+        else
+          default_breadcrumb_links(path)
+        end
+      end
 
+      def default_breadcrumb_links(path)
         # remove leading "/" and split up the URL
         # and remove last since it's used as the page title
         parts = path.split('/').select(&:present?)[0..-2]

--- a/lib/active_admin/view_helpers/breadcrumb_helper.rb
+++ b/lib/active_admin/view_helpers/breadcrumb_helper.rb
@@ -15,6 +15,9 @@ module ActiveAdmin
         end
       end
 
+      GUID_REGEX = '(?:[a-f0-9]{8}-(?:[a-f0-9]{4}-){3}[a-f0-9]{12})'
+      ID_REGEX = '\d+|[a-f0-9]{24}|' + GUID_REGEX
+
       def default_breadcrumb_links(path)
         # remove leading "/" and split up the URL
         # and remove last since it's used as the page title
@@ -24,7 +27,7 @@ module ActiveAdmin
           # 1. try using `display_name` if we can locate a DB object
           # 2. try using the model name translation
           # 3. default to calling `titlecase` on the URL fragment
-          if part =~ /\A(\d+|[a-f0-9]{24}|(?:[a-f0-9]{8}-(?:[a-f0-9]{4}-){3}[a-f0-9]{12}))\z/ && parts[index-1]
+          if part =~ /\A(#{ID_REGEX})\z/ && parts[index-1]
             parent = active_admin_config.belongs_to_config.try :target
             config = parent && parent.resource_name.route_key == parts[index-1] ? parent : active_admin_config
             name   = display_name config.find_resource part


### PR DESCRIPTION
Allow breadcrumbs to be customized by overriding a partial instead of a configuration proc.