### PR TITLE
Add ActiveAdmin.configure_resource and configure_page

### DIFF
--- a/lib/active_admin.rb
+++ b/lib/active_admin.rb
@@ -72,6 +72,8 @@ module ActiveAdmin
       application.prepare!
     end
 
+    delegate :configure_resource, to: :application
+    delegate :configure_page,     to: :application
     delegate :register,      to: :application
     delegate :register_page, to: :application
     delegate :unload!,       to: :application

--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -65,6 +65,11 @@ module ActiveAdmin
       attach_reloader
     end
 
+    def configure_resource(resource, options = {}, &block)
+      ns = options.fetch(:namespace){ default_namespace }
+      namespace(ns).configure_resource resource, options, &block
+    end
+
     # Registers a brand new configuration for the given resource.
     def register(resource, options = {}, &block)
       ns = options.fetch(:namespace){ default_namespace }
@@ -88,6 +93,11 @@ module ActiveAdmin
       yield(namespace) if block_given?
 
       namespace
+    end
+
+    def configure_page(name, options = {}, &block)
+      ns = options.fetch(:namespace){ default_namespace }
+      namespace(ns).configure_page name, options, &block
     end
 
     # Register a page

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -77,6 +77,28 @@ module ActiveAdmin
       config
     end
 
+    # Add or update resource configuration options.
+    #
+    # Assumes corresponding Rails Controller class already exists.
+    # Block is evaluated within config, not parsed as DSL.
+    #
+    # @param [Class] resource_class. ActiveRecord model.
+    #
+    # @return [Resource]
+    def configure_resource(resource_class, options = {}, &block)
+      config = find_or_build_resource(resource_class, options)
+
+      raise "#{config.controller_name} not found" unless Object.const_defined?(config.controller_name)
+      config.controller.active_admin_config = config
+
+      yield(config) if block_given?
+      reset_menu!
+
+      ActiveSupport::Notifications.publish ActiveAdmin::Resource::RegisterEvent, config
+
+      config
+    end
+
     def register_page(name, options = {}, &block)
       config = build_page(name, options)
 

--- a/lib/active_admin/namespace.rb
+++ b/lib/active_admin/namespace.rb
@@ -110,6 +110,26 @@ module ActiveAdmin
       config
     end
 
+    # Add page configuration options.
+    #
+    # Assumes corresponding Rails Controller class already exists.
+    # Block is evaluated within config, not parsed as DSL.
+    #
+    # @param [String] name.
+    #
+    # @return [Resource]
+    def configure_page(name, options = {}, &block)
+      config = build_page(name, options)
+
+      raise "#{config.controller_name} not found" unless Object.const_defined?(config.controller_name)
+      config.controller.active_admin_config = config
+
+      yield(config) if block_given?
+      reset_menu!
+
+      config
+    end
+
     def root?
       name == :root
     end


### PR DESCRIPTION
Replacements for register and register_page that provide a simple builder style initialization block instead of parsing DSL.