### PR TITLE
Add ActionLink view component: a Rails link wrapped with a styled span.

### DIFF
--- a/lib/active_admin/views/components/action_link.rb
+++ b/lib/active_admin/views/components/action_link.rb
@@ -1,0 +1,13 @@
+module ActiveAdmin
+  module Views
+    class ActionLink < Arbo::HTML::Span
+      builder_method :action_link
+
+      def build(name, path, options = {})
+        @tag_name = 'span'
+        set_attribute(:class, :action_item)
+        text_node link_to(localizer.t(name), path, options)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Convenient macro for action_items partials.